### PR TITLE
Add must util tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "db:migrate": "drizzle-kit migrate",
     "db:studio": "drizzle-kit studio",
     "db:push": "drizzle-kit push --force",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit",
+    "test": "vitest run"
   },
   "keywords": [],
   "author": "",
@@ -50,6 +51,7 @@
     "drizzle-kit": "^0.31.4",
     "drizzle-zero": "^0.13.1",
     "tsx": "^4.20.3",
+    "vitest": "^1.5.0",
     "typescript": "^5.8.3",
     "vite-tsconfig-paths": "^5.1.4",
     "wait-on": "^8.0.4"

--- a/src/shared/util/must.test.ts
+++ b/src/shared/util/must.test.ts
@@ -1,0 +1,13 @@
+import {describe, it, expect} from 'vitest';
+import {must} from './must.js';
+
+describe('must', () => {
+  it('throws for undefined', () => {
+    expect(() => must(undefined)).toThrowError();
+  });
+
+  it('returns value', () => {
+    const result: string = must('value');
+    expect(result).toBe('value');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Summary
- add tests for the `must` utility
- wire up a simple test script using vitest

## Testing
- `npm test --silent` *(fails: vitest not found)*
- `npm install vitest --save-dev --silent` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688cb17a8a78832485ba5976e0936d37